### PR TITLE
Fixed Mypy and Python 3.11 compatibility issues on feature/target-config-only branch

### DIFF
--- a/logging518/config.py
+++ b/logging518/config.py
@@ -26,12 +26,12 @@ def fileConfig(fname: Union[str, Path]) -> None:
 
     # tomli/tomlib compatibility layer
     try:
-        import tomlib  # type: ignore
+        import tomllib  # type: ignore
     except ModuleNotFoundError:
-        import tomli as tomlib  # type: ignore
+        import tomli as tomllib  # type: ignore
 
     with open(fname, "rb") as stream:
-        toml_dict = tomlib.load(stream)
+        toml_dict = tomllib.load(stream)
 
     tool_table = toml_dict.get("tool", {})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = [".devcontainer/", ".github/"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-tomli = "^2.0.1"
+tomli = { version = "^2.0.1", python = "<3.11" }
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -4,9 +4,9 @@ import logging518.config
 import pytest
 
 try:
-    import tomlib
+    import tomllib
 except ModuleNotFoundError:
-    import tomli as tomlib
+    import tomli as tomllib
 
 
 def test_successful_config():
@@ -22,7 +22,7 @@ def test_successful_config():
 
 
 def test_failure_config():
-    with pytest.raises(tomlib.TOMLDecodeError):
+    with pytest.raises(tomllib.TOMLDecodeError):
         logging518.config.fileConfig("tests/mock/failure.toml")
 
 


### PR DESCRIPTION
I did some testing with the **python:3.10** and **python:3.11-rc** containers to validate **logging518@feature/target-config-only**.

With these changes:
1. Python 3.10 installs **tomli**; tests are passing
2. Python 3.11-rc _does not_ install **tomli** and uses the built-in tomllib; tests are passing

Cheers!
